### PR TITLE
onerroadded incase the image profile is missing

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -24,7 +24,7 @@ const LoggedOutView = (props) => {
 };
 
 const LoggedInView = (props) => {
-  if (props.currentUser) {
+  if (props?.currentUser) {
     return (
       <ul className="navbar-nav ml-auto">
         {props.currentUser.role === "admin" && (
@@ -48,8 +48,9 @@ const LoggedInView = (props) => {
               className="user-pic pr-1"
               alt={props.currentUser.username}
               onError={({ currentTarget }) => {
-                currentTarget.onerror = null; // prevents looping
-                currentTarget.src='https://static.productionready.io/images/smiley-cyrus.jpg';
+                currentTarget.onerror = null;
+                currentTarget.src =
+                  "https://static.productionready.io/images/smiley-cyrus.jpg";
               }}
             />
             {props.currentUser.username}

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -49,7 +49,7 @@ const LoggedInView = (props) => {
               alt={props.currentUser.username}
               onError={({ currentTarget }) => {
                 currentTarget.onerror = null; // prevents looping
-                currentTarget.src="https://static.productionready.io/images/smiley-cyrus.jpg";
+                currentTarget.src='https://static.productionready.io/images/smiley-cyrus.jpg';
               }}
             />
             {props.currentUser.username}

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -47,6 +47,10 @@ const LoggedInView = (props) => {
               src={props.currentUser.image}
               className="user-pic pr-1"
               alt={props.currentUser.username}
+              onError={({ currentTarget }) => {
+                currentTarget.onerror = null; // prevents looping
+                currentTarget.src="https://static.productionready.io/images/smiley-cyrus.jpg";
+              }}
             />
             {props.currentUser.username}
           </Link>


### PR DESCRIPTION
# Description

when the user was just created the profile image is not exist, and even if the user added a url to his profile image - it might return 404
so i added "onerror" to the image component

Fixes # (if relevant)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Refactoring

# How Has This Been Tested?

1. tested when the user was just created (empty value in the profile image)
2. tested with url to an exist image (url reurned 200)
3. tested when url was broken
4. tested when the user delete his url from the profile settings page

**If this is a UI change / fix, please also add a screenshot**

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I added the relevant people as reviewers to my PR
![Screen Shot 2022-05-03 at 17 38 17](https://user-images.githubusercontent.com/16078646/166478132-f500932f-e435-4dbf-afeb-2be087440523.png)
![Screen Shot 2022-05-03 at 17 38 31](https://user-images.githubusercontent.com/16078646/166478150-4236cf53-768e-4f2e-8eea-c7b5fe4de31f.png)
![Screen Shot 2022-05-03 at 17 47 17](https://user-images.githubusercontent.com/16078646/166478156-755d9a81-db3e-48af-8ec1-d12d4aa9065e.png)

